### PR TITLE
entprint: permit skipping normalizer if not implemented

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,28 @@ name: test
 on:
   push:
 jobs:
+  test-sqlite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.0.2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - name: print
+        run: |
+          go run . --dir ./internal/example/ent/schema --dev="sqlite3://test?_fk=1" > internal/example/ent/sqlite3.hcl
+          cat internal/example/ent/sqlite3.hcl
+          rm test
+      - name: verify no diff
+        run: |
+          status=$(git status --porcelain)
+          if [ -n "$status" ]; then
+            echo "diff between generated hcl file and checked in file"
+            echo "$status"
+            git diff
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -57,7 +79,7 @@ jobs:
         run: |
           status=$(git status --porcelain)
           if [ -n "$status" ]; then
-            echo "diff between generated hcl file and checked in file" 
+            echo "diff between generated hcl file and checked in file"
             echo "$status"
             git diff
             exit 1

--- a/internal/example/ent/sqlite3.hcl
+++ b/internal/example/ent/sqlite3.hcl
@@ -1,0 +1,13 @@
+table "users" {
+  schema = schema.main
+  column "id" {
+    null           = false
+    type           = integer
+    auto_increment = true
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+schema "main" {
+}

--- a/main.go
+++ b/main.go
@@ -65,12 +65,11 @@ func main() {
 		log.Fatalf("connecting: %v", err)
 	}
 	norm, ok := drv.Driver.(atlas.Normalizer)
-	if !ok {
-		log.Fatalf("driver %T does not impl Normalizer", drv.Driver)
-	}
-	sch, err = norm.NormalizeSchema(context.Background(), sch)
-	if err != nil {
-		log.Fatalf("normalzing schema: %v", err)
+	if ok {
+		sch, err = norm.NormalizeSchema(context.Background(), sch)
+		if err != nil {
+			log.Fatalf("normalzing schema: %v", err)
+		}
 	}
 	spec, err := drv.MarshalSpec(sch)
 	if err != nil {


### PR DESCRIPTION
**Summary:** Allows normalizer skips for unimplemented drivers (such as SQLite.)


```shell
➜  entprint git:(sqlite-support) ✗ go run . --dir=./internal/example/ent/schema --dev="sqlite3://test?_fk=1"
table "users" {
  schema = schema.main
  column "id" {
    null           = false
    type           = integer
    auto_increment = true
  }
  primary_key {
    columns = [column.id]
  }
}
schema "main" {
}
```